### PR TITLE
load integral panel strings at init rather than at load

### DIFF
--- a/LuaUI/Widgets/gui_chili_integral_menu.lua
+++ b/LuaUI/Widgets/gui_chili_integral_menu.lua
@@ -90,7 +90,7 @@ end
 --------------------------------------------------------------------------------
 -- Command Handling and lower variables
 
-local commandPanels, commandPanelMap, commandDisplayConfig, hiddenCommands, textConfig, buttonLayoutConfig, instantCommands, cmdPosDef = include("Configs/integral_menu_config.lua")
+local commandPanels, commandPanelMap, commandDisplayConfig, hiddenCommands, textConfig, buttonLayoutConfig, instantCommands, cmdPosDef
 
 local fontObjects = {} -- Filled in init
 
@@ -2529,7 +2529,10 @@ function widget:Initialize()
 	Progressbar = Chili.Progressbar
 	Control = Chili.Control
 	screen0 = Chili.Screen0
-	
+
+    commandPanels, commandPanelMap, commandDisplayConfig, hiddenCommands, textConfig, buttonLayoutConfig, instantCommands, cmdPosDef = include("Configs/integral_menu_config.lua")
+
+
 	InitializeFonts()
 	InitializeControls()
 	


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3822768/96636757-6b9bf500-1326-11eb-8be1-f3aefad5dc53.png)
